### PR TITLE
Implement GetOperands & PluralRuleSelection using make-plural.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "grunt-curl": "^2.1.0",
     "grunt-zip": "^0.16.2",
     "jshint": "^2.5.5",
+    "make-plural": "^4.0.1",
     "mkdirp": "^0.5.1",
     "object.assign": "^1.1.1",
     "rimraf": "^2.4.2",

--- a/src/14.pluralrules.js
+++ b/src/14.pluralrules.js
@@ -1,3 +1,5 @@
+import plurals from 'make-plural/es6/plurals';
+
 import {
   Intl
 } from './8.intl.js';
@@ -106,54 +108,13 @@ export function InitializePluralRules (pluralRules, locales, options) {
   return pluralRules;
 }
 
-function GetOperands(s) {
-  let n = Number(s);
-  let dp = s.indexOf('.');
-
-  let iv, fv, ft, f, v, w, t;
-
-  if (dp === -1) {
-    iv = n;
-    f = 0;
-    v = 0;
-  } else {
-    iv = s.substring(0, dp);
-    fv = s.substring(dp);
-    f = Number(fv);
-    v = fv.length;
+// make-plural also handles GetOperands
+function PluralRuleSelection(locale, type, s) {
+  for (let l = locale; l; l = l.replace(/[-_]?[^-_]*$/, '')) {
+    const pf = plurals[l];
+    if (pf) return pf(s, type === 'ordinal');
   }
-
-  let i = Math.abs(Number(iv));
-
-  if (f !== 0) {
-    ft = fv;
-    while (ft.endsWith('0')) {
-      ft = ft.substr(-1);
-    }
-    w = ft.length;
-    t = Number(ft);
-  } else {
-    w = 0;
-    t = 0;
-  }
-  let result = new Record();
-  result['[[Number]]'] = n;
-  result['[[IntegerDigits]]'] = i;
-  result['[[NumberOfFractioNDigits]]'] = v;
-  result['[[NumberOfFractionDigitsWithoutTrailing]]'] = w;
-  result['[[FractionDigits]]'] = f;
-  result['[[FractionDigitsWithoutTrailing]]'] = t;
-  return result;
-}
-
-function PluralRuleSelection(locale, type, n, operands) {
-  let localeData = internals.PluralRules['[[localeData]]'];
-
-  let fn = localeData[locale][type];
-
-  return fn(
-    operands['[[Number]]']
-  );
+  return 'other';
 }
 
 function ResolvePlural(pluralRules, n) {
@@ -165,8 +126,7 @@ function ResolvePlural(pluralRules, n) {
   let locale = internal['[[Locale]]'];
   let type = internal['[[Type]]'];
   let s = FormatNumberToString(pluralRules, n);
-  let operands = GetOperands(s);
-  return PluralRuleSelection(locale, type, n, operands);
+  return PluralRuleSelection(locale, type, s);
 }
 
 internals.PluralRules = {


### PR DESCRIPTION
As make-plural.js itself handles the operand calculation and accepts string input, I've here removed also `GetOperands`; this means that the call parameters of this `PluralRuleSelection` use `s` rather than `n` and `operands`.

I'm not sure if there'd be a preferred way here of acquiring the `plurals` object. The latest make-plural.js builds it from CLDR v30; if there's a need to use the the local CLDR data, a pre-processing stage will be needed to run its compiler using that data.
